### PR TITLE
Fix import path in analyze API

### DIFF
--- a/pages/api/analyze.js
+++ b/pages/api/analyze.js
@@ -1,3 +1,4 @@
+import { getPatternsByDomainAndCategory } from '../../utils/loadStructurePatterns';
 const { analyzeText } = require('@/lib/lang/analyzer');
 
 export default function handler(req, res) {


### PR DESCRIPTION
## Summary
- update analyze API import path

## Testing
- `npm run lint` *(fails: React must be in scope, require is not defined, etc.)*