### PR TITLE
Add domain/category analysis API and simple form

### DIFF
--- a/pages/api/analyze.js
+++ b/pages/api/analyze.js
@@ -6,15 +6,16 @@ export default function handler(req, res) {
     return res.status(405).json({ message: 'Method Not Allowed' });
   }
 
-  const { text, locale } = req.body;
+  const { text, domain, category, locale } = req.body;
 
   if (!text) {
     return res.status(400).json({ message: 'Missing text to analyze' });
   }
 
   try {
-    const results = analyzeText(text, locale || 'ar');
-    return res.status(200).json({ results });
+    const analysis = analyzeText(text, locale || 'ar');
+    const patterns = getPatternsByDomainAndCategory(domain, category);
+    return res.status(200).json({ analysis, patterns });
   } catch (error) {
     console.error('❌ تحليل فشل:', error);
     return res.status(500).json({ message: 'Internal Server Error' });

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,16 +1,49 @@
-import Head from "next/head";
-import RFPAssistant from "@/components/RFPAssistant";
+import Head from 'next/head';
+import { useState } from 'react';
 
 export default function Home() {
+  const [text, setText] = useState('');
+  const [domain, setDomain] = useState('');
+  const [category, setCategory] = useState('');
+  const [results, setResults] = useState(null);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const res = await fetch('/api/analyze', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text, domain, category }),
+    });
+    const data = await res.json();
+    setResults(data);
+  };
+
   return (
     <>
       <Head>
         <title>منصة RFP الذكية</title>
       </Head>
       <main>
-        <RFPAssistant />
+        <form onSubmit={handleSubmit}>
+          <input
+            placeholder="Domain"
+            value={domain}
+            onChange={(e) => setDomain(e.target.value)}
+          />
+          <input
+            placeholder="Category"
+            value={category}
+            onChange={(e) => setCategory(e.target.value)}
+          />
+          <textarea
+            placeholder="Text"
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+          />
+          <button type="submit">Analyze</button>
+        </form>
+        {results && <pre>{JSON.stringify(results, null, 2)}</pre>}
       </main>
     </>
   );
 }
-

--- a/utils/loadStructurePatterns.js
+++ b/utils/loadStructurePatterns.js
@@ -1,0 +1,20 @@
+import fs from 'fs';
+import path from 'path';
+
+export function getPatternsByDomainAndCategory(domain, category) {
+  const filePath = path.join(process.cwd(), 'data', 'ai', 'structure_patterns.json');
+  let patterns = [];
+  try {
+    const raw = fs.readFileSync(filePath, 'utf-8');
+    patterns = JSON.parse(raw);
+  } catch (err) {
+    console.error('Failed to load patterns file', err);
+    return [];
+  }
+
+  return patterns.filter((p) => {
+    const domainOk = !domain || p.domain.toLowerCase() === domain.toLowerCase();
+    const categoryOk = !category || p.category === category;
+    return domainOk && categoryOk;
+  });
+}


### PR DESCRIPTION
## Summary
- return patterns and analysis from the `/api/analyze` endpoint
- add helper for filtering patterns by domain and category
- replace the index page with a small form that posts to `/api/analyze`

## Testing
- `npm run lint` *(fails: 'React' must be in scope and other lint errors)*