### PR TITLE
Persist RFP data using localStorage

### DIFF
--- a/components/CreateRFP.jsx
+++ b/components/CreateRFP.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { useRouter } from "next/router";
 
 export default function CreateRFP() {
@@ -30,6 +30,16 @@ export default function CreateRFP() {
   const currentKey = questions[index].key;
 
   const rfpData = answers;
+
+  useEffect(() => {
+    if (completed) {
+      try {
+        localStorage.setItem("rfpData", JSON.stringify(rfpData));
+      } catch {
+        // Ignore write errors
+      }
+    }
+  }, [completed, rfpData]);
 
   const handlePreview = () => {
     router.push({

--- a/pages/preview.js
+++ b/pages/preview.js
@@ -1,34 +1,36 @@
-import React from 'react';
-import Head from 'next/head';
-import RFPPreview from '@/components/RFPPreview';
+import React, { useState, useEffect } from "react";
+import Head from "next/head";
+import { useRouter } from "next/router";
+import RFPPreview from "@/components/RFPPreview";
 
 export default function PreviewPage() {
-  const rfpData = {
-    projectInfo:
-      'اسم المشروع: حملة إطلاق المنتج الجديد\nالجهة الطالبة: شركة الابتكار للتسويق\nرقم المرجع: 2024-01',
-    background:
-      'تسعى الشركة إلى توسيع حضورها في السوق المحلي بإطلاق منتج تقني يستهدف فئة الشباب. يأتي هذا الطلب للحصول على عروض من وكالات متخصصة لإدارة الحملة بالكامل وتحقيق أقصى انتشار ممكن.',
-    projectDescription:
-      'يتضمن المشروع إعداد خطة تسويق شاملة، إنتاج المحتوى الرقمي، وإدارة الإعلانات المدفوعة على المنصات الاجتماعية ومحركات البحث. يجب أن تعكس الحملة هوية العلامة التجارية وأن تبرز نقاط تميز المنتج.',
-    scopeOfWork:
-      'يشمل نطاق العمل تطوير الاستراتيجية، تصميم الإعلانات، إدارة حسابات التواصل الاجتماعي، وتنفيذ أنشطة العلاقات العامة ذات الصلة.',
-    targetAudience:
-      'الفئة المستهدفة هي الشباب من عمر 18 إلى 30 عاماً في المدن الرئيسية ممن يهتمون بالتقنية وأسلوب الحياة العصري.',
-    deliverables:
-      '1. خطة تسويق تفصيلية\n2. محتوى إعلاني بصري ونصي\n3. تقارير أداء شهرية\n4. ملخص ختامي للحملة',
-    timeline:
-      'بداية التنفيذ: 1 يونيو 2024\nانتهاء الحملة: 31 أغسطس 2024',
-    budget:
-      'الميزانية الإجمالية المقدرة تتراوح بين 150,000 و 200,000 ريال سعودي وتشمل تكاليف الإعلان والإنتاج.',
-    evaluationCriteria:
-      'سيتم تقييم العروض بناءً على خبرة الفريق، جودة الخطة التسويقية، القدرة على الابتكار، والالتزام بالجدول الزمني المقترح.',
-    submissionRequirements:
-      'يجب أن يتضمن العرض نبذة عن الوكالة، أمثلة لأعمال سابقة مشابهة، المنهجية المقترحة، والفريق الرئيسي الذي سيعمل على المشروع.',
-    questions:
-      'يمكن إرسال الاستفسارات حتى 10 مايو 2024 على البريد marketing@example.com وسيتم الرد خلال يومي عمل.',
-    attachments:
-      'مرفق مع هذا الطلب دليل الهوية البصرية للعلامة التجارية بالإضافة إلى ملخص عن المنتج.',
-  };
+  const router = useRouter();
+  const [rfpData, setRfpData] = useState(null);
+
+  useEffect(() => {
+    if (!router.isReady) return;
+
+    let data = null;
+    if (router.query.rfp) {
+      try {
+        data = JSON.parse(router.query.rfp);
+        setRfpData(data);
+        localStorage.setItem("rfpData", JSON.stringify(data));
+      } catch {
+        // ignore invalid data
+      }
+    } else {
+      const saved = localStorage.getItem("rfpData");
+      if (saved) {
+        try {
+          data = JSON.parse(saved);
+          setRfpData(data);
+        } catch {
+          // ignore invalid saved data
+        }
+      }
+    }
+  }, [router.isReady, router.query]);
 
   return (
     <>
@@ -36,7 +38,13 @@ export default function PreviewPage() {
         <title>معاينة العرض</title>
       </Head>
       <div className="min-h-screen bg-gray-50 p-4 flex justify-center">
-        <RFPPreview data={rfpData} />
+        {rfpData ? (
+          <RFPPreview data={rfpData} />
+        ) : (
+          <p dir="rtl" className="text-gray-700">
+            لا توجد بيانات لعرضها.
+          </p>
+        )}
       </div>
     </>
   );


### PR DESCRIPTION
## Summary
- store finished RFP answers in `localStorage`
- recover RFP data on the preview page from router state or `localStorage`

## Testing
- `npm test` *(fails: Missing script)*