### PR TITLE
Enhance RFP creation assistant hints

### DIFF
--- a/components/ConversationView.jsx
+++ b/components/ConversationView.jsx
@@ -25,20 +25,19 @@ export default function ConversationView({ messages = [], isLoading = false }) {
             msg.content
           ) : (
             <div className="space-y-1">
-              <p className="font-semibold text-gray-800">{msg.content.prompt}</p>
+              <p className="font-semibold text-blue-700">{msg.content.prompt}</p>
               {msg.content.help && (
-                <p className="text-gray-600 text-sm">{msg.content.help}</p>
+                <p className="text-gray-700 text-sm">{msg.content.help}</p>
               )}
               {msg.content.intent && (
                 <p className="text-xs text-gray-500">🎯 {msg.content.intent}</p>
               )}
-              {msg.content.marketing && (
-                <p className="text-xs text-green-700">
-                  {msg.content.marketing}
-                </p>
-              )}
-              {msg.content.pr && (
-                <p className="text-xs text-purple-700">{msg.content.pr}</p>
+              {(msg.content.marketing || msg.content.pr) && (
+                <div className="text-xs text-gray-600 space-y-0.5">
+                  <p className="font-medium">🧠 مثال:</p>
+                  {msg.content.marketing && <p>- {msg.content.marketing}</p>}
+                  {msg.content.pr && <p>- {msg.content.pr}</p>}
+                </div>
               )}
             </div>
           )}

--- a/components/CreateRFP.jsx
+++ b/components/CreateRFP.jsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useRouter } from "next/router";
 import ConversationView from "@/components/ConversationView";
 import { rfpHints } from "@/data/assistant/rfpHints";
@@ -36,14 +36,18 @@ export default function CreateRFP() {
   const [index, setIndex] = useState(0);
   const [answers, setAnswers] = useState({});
   const [input, setInput] = useState("");
-  const [messages, setMessages] = useState([
-    {
-      role: "assistant",
-      content: buildHint(questionKeys[0]),
-      timestamp: Date.now(),
-    },
-  ]);
+  const [messages, setMessages] = useState([]);
   const [redirecting, setRedirecting] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const first = buildHint(questionKeys[0]);
+    const t = setTimeout(() => {
+      setMessages([{ role: "assistant", content: first, timestamp: Date.now() }]);
+      setIsLoading(false);
+    }, 600);
+    return () => clearTimeout(t);
+  }, []);
 
   const handleSend = (e) => {
     e.preventDefault();
@@ -64,13 +68,17 @@ export default function CreateRFP() {
 
     if (index < questionKeys.length - 1) {
       const nextKey = questionKeys[index + 1];
-      const assistantMessage = {
-        role: "assistant",
-        content: buildHint(nextKey),
-        timestamp: Date.now(),
-      };
-      setMessages((prev) => [...prev, assistantMessage]);
-      setIndex(index + 1);
+      setIsLoading(true);
+      setTimeout(() => {
+        const assistantMessage = {
+          role: "assistant",
+          content: buildHint(nextKey),
+          timestamp: Date.now(),
+        };
+        setMessages((prev) => [...prev, assistantMessage]);
+        setIndex((i) => i + 1);
+        setIsLoading(false);
+      }, 600);
     } else {
       try {
         localStorage.setItem("rfpData", JSON.stringify(updated));
@@ -93,7 +101,7 @@ export default function CreateRFP() {
 
   return (
     <div dir="rtl" className="max-w-xl mx-auto p-4 space-y-4">
-      <ConversationView messages={messages} />
+      <ConversationView messages={messages} isLoading={isLoading} />
       {!redirecting && (
         <form onSubmit={handleSend} className="flex gap-2">
           <input
@@ -106,6 +114,7 @@ export default function CreateRFP() {
           <button
             type="submit"
             className="bg-blue-600 text-white px-4 py-2 rounded"
+            disabled={isLoading}
           >
             إرسال
           </button>


### PR DESCRIPTION
## Summary
- delay first hint and show typing indicator while assistant 'types'
- disable the answer form until the assistant hint is visible
- style hint message with blue prompt and grey help text
- show example section with heading '🧠 مثال:' in conversation view

## Testing
- `npm run lint` *(fails: no-undef & prop-types issues)*