### PR TITLE
Update PostCSS config to ESM format

### DIFF
--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,5 +1,6 @@
-const config = {
-  plugins: ["@tailwindcss/postcss"],
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
 };
-
-export default config;


### PR DESCRIPTION
## Summary
- use ES Module syntax in `postcss.config.mjs`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails to pass ESLint rules)*