### PR TITLE
Fix module path resolution for RFP preview

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "paths": {
       "@/*": ["./*"]
     }


### PR DESCRIPTION
## Summary
- ensure jsconfig specifies baseUrl for path alias

## Testing
- `npm run lint`
