### PR TITLE
Fix API validation and add marketing request form

### DIFF
--- a/pages/api/create-rfp.js
+++ b/pages/api/create-rfp.js
@@ -1,4 +1,30 @@
 export default function handler(req, res) {
-  const data = req.body || null;
-  return res.status(200).json({ message: "Received", data });
+  if (req.method !== "POST") {
+    res.setHeader("Allow", ["POST"]);
+    return res.status(405).json({ error: "Method Not Allowed" });
+  }
+
+  try {
+    const {
+      companyName,
+      contactPerson,
+      projectTitle,
+      requestDetails,
+    } = req.body || {};
+
+    if (!companyName || !projectTitle || !requestDetails || !contactPerson) {
+      return res
+        .status(400)
+        .json({ error: "Missing required fields" });
+    }
+
+    const data = { companyName, contactPerson, projectTitle, requestDetails };
+
+    return res
+      .status(200)
+      .json({ message: "RFP submitted successfully", data });
+  } catch (err) {
+    console.error("create-rfp error", err);
+    return res.status(500).json({ error: "Internal Server Error" });
+  }
 }

--- a/pages/marketing-request.js
+++ b/pages/marketing-request.js
@@ -1,0 +1,86 @@
+import React, { useState } from "react";
+import { useRouter } from "next/router";
+
+export default function MarketingRequest() {
+  const router = useRouter();
+  const [companyName, setCompanyName] = useState("");
+  const [contactPerson, setContactPerson] = useState("");
+  const [projectTitle, setProjectTitle] = useState("");
+  const [requestDetails, setRequestDetails] = useState("");
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const data = { companyName, contactPerson, projectTitle, requestDetails };
+    try {
+      await fetch("/api/create-rfp", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(data),
+      });
+      localStorage.setItem("rfpData", JSON.stringify(data));
+      router.push("/preview");
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50 flex items-center justify-center p-6" dir="rtl">
+      <form
+        onSubmit={handleSubmit}
+        className="bg-white rounded-xl shadow-md p-6 space-y-4 w-full max-w-lg"
+      >
+        <div>
+          <label className="block mb-1">اسم الشركة</label>
+          <input
+            type="text"
+            value={companyName}
+            onChange={(e) => setCompanyName(e.target.value)}
+            placeholder="اسم الشركة"
+            className="w-full border border-gray-300 rounded px-3 py-2"
+            required
+          />
+        </div>
+        <div>
+          <label className="block mb-1">الشخص المسؤول</label>
+          <input
+            type="text"
+            value={contactPerson}
+            onChange={(e) => setContactPerson(e.target.value)}
+            placeholder="الشخص المسؤول"
+            className="w-full border border-gray-300 rounded px-3 py-2"
+            required
+          />
+        </div>
+        <div>
+          <label className="block mb-1">عنوان المشروع</label>
+          <input
+            type="text"
+            value={projectTitle}
+            onChange={(e) => setProjectTitle(e.target.value)}
+            placeholder="عنوان المشروع"
+            className="w-full border border-gray-300 rounded px-3 py-2"
+            required
+          />
+        </div>
+        <div>
+          <label className="block mb-1">تفاصيل الطلب</label>
+          <textarea
+            value={requestDetails}
+            onChange={(e) => setRequestDetails(e.target.value)}
+            placeholder="تفاصيل الطلب"
+            className="w-full border border-gray-300 rounded px-3 py-2"
+            rows="4"
+            required
+          />
+        </div>
+        <button
+          type="submit"
+          className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded w-full"
+        >
+          إرسال الطلب
+        </button>
+      </form>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- validate POST requests in `create-rfp` API
- return errors for missing fields
- log and handle unexpected API errors
- add a marketing request form for RFP creation

## Testing
- `npm run lint` *(fails: `npm` not found)*